### PR TITLE
CPAN::Meta needs load_file()

### DIFF
--- a/lib/RTx/ToGitHub.pm
+++ b/lib/RTx/ToGitHub.pm
@@ -349,7 +349,7 @@ sub _build_dist {
 sub _dist_from_local_files {
     my ($meta) = grep {-r} qw( MYMETA.json MYMETA.yml META.json META.yml );
     if ($meta) {
-        my $cm = CPAN::Meta->new($meta);
+        my $cm = CPAN::Meta->load_file($meta);
         return $cm->name;
     }
     elsif ( -r 'dist.ini' ) {


### PR DESCRIPTION
Hi, I wanted to use this script to convert some issues for one of my repos and I found that it does not work for me - I need to use `load_file()` to load the `META.json` file.